### PR TITLE
Area selector color coding

### DIFF
--- a/closing-report-helper.js
+++ b/closing-report-helper.js
@@ -152,10 +152,10 @@ document.body.onload = () => {
   runDifferenceObserver();
 
   // Some style changes to the area selector and difference fields
-  // Object.assign(document.querySelector('select#area'), { multiple: true });
   const originalAreaSelector = document.querySelector('select#area');
   const originalAreaOptions = document.querySelectorAll('select#area option');
 
+  // Set the button colors for each area
   const areaColor = {
     1: '#bbf7d0',
     2: '#fbcfe8',
@@ -167,17 +167,20 @@ document.body.onload = () => {
     8: '#facc15',
   };
 
+  // Create a wrapper div for the button group and insert it
   const buttonsDiv = Object.assign(document.createElement('div'), {
     id: 'area-buttons',
   });
   originalAreaSelector.insertAdjacentElement('afterend', buttonsDiv);
 
+  // Make the first button a label for the group
   const labelButton = Object.assign(document.createElement('button'), {
     innerHTML: 'Area',
     style: 'background-color: rgba(0, 0, 0, 0.1);',
   });
   buttonsDiv.insertAdjacentElement('beforeend', labelButton);
 
+  // Each area selector gets a button with similar properties
   originalAreaOptions.forEach((area) => {
     const areaButton = Object.assign(document.createElement('button'), {
       id: `area-${area.value}`,
@@ -186,6 +189,8 @@ document.body.onload = () => {
       style: `background-color: ${areaColor[area.value]};`,
     });
 
+    // Add a click listener to spoof the original selector
+    // (utilizing the built-in onchange function)
     areaButton.addEventListener('click', () => {
       document.querySelector(`select#area option[value="${area.value}"]`).selected = true;
       document.querySelectorAll('#area-buttons button').forEach((btn) => {
@@ -197,9 +202,11 @@ document.body.onload = () => {
       });
       originalAreaSelector.dispatchEvent(new Event('change'));
     });
+    // Insert the new button at the end of the div
     buttonsDiv.insertAdjacentElement('beforeend', areaButton);
   });
 
+  // Inject an inline stylesheet
   const selectorStyle = Object.assign(document.createElement('style'), {
     innerHTML: `
       select#area{

--- a/closing-report-helper.js
+++ b/closing-report-helper.js
@@ -152,24 +152,87 @@ document.body.onload = () => {
   runDifferenceObserver();
 
   // Some style changes to the area selector and difference fields
-  Object.assign(document.querySelector('select#area'), { multiple: true });
+  // Object.assign(document.querySelector('select#area'), { multiple: true });
+  const originalAreaSelector = document.querySelector('select#area');
+  const originalAreaOptions = document.querySelectorAll('select#area option');
+
+  const areaColor = {
+    1: '#bbf7d0',
+    2: '#fbcfe8',
+    3: '#fef08a',
+    4: '#fda4af',
+    5: '#bfdbfe',
+    6: '#ddd6fe',
+    7: '#fed7aa',
+    8: '#facc15',
+  };
+
+  const buttonsDiv = Object.assign(document.createElement('div'), {
+    id: 'area-buttons',
+  });
+  originalAreaSelector.insertAdjacentElement('afterend', buttonsDiv);
+
+  const labelButton = Object.assign(document.createElement('button'), {
+    innerHTML: 'Area',
+    style: 'background-color: rgba(0, 0, 0, 0.1);',
+  });
+  buttonsDiv.insertAdjacentElement('beforeend', labelButton);
+
+  originalAreaOptions.forEach((area) => {
+    const areaButton = Object.assign(document.createElement('button'), {
+      id: `area-${area.value}`,
+      value: area.value,
+      innerHTML: area.innerHTML.match(/Area ([1-8]{1})/i)[1],
+      style: `background-color: ${areaColor[area.value]};`,
+    });
+
+    areaButton.addEventListener('click', () => {
+      document.querySelector(`select#area option[value="${area.value}"]`).selected = true;
+      document.querySelectorAll('#area-buttons button').forEach((btn) => {
+        if (btn.value === areaButton.value) {
+          btn.setAttribute('class', 'active');
+        } else {
+          btn.setAttribute('class', '');
+        }
+      });
+      originalAreaSelector.dispatchEvent(new Event('change'));
+    });
+    buttonsDiv.insertAdjacentElement('beforeend', areaButton);
+  });
+
   const selectorStyle = Object.assign(document.createElement('style'), {
     innerHTML: `
       select#area{
-        height: 50px;
-        border: none;
-        overflow: hidden;
+        display: none;
       }
-      select#area:focus {
-        outline: none;
+      #area-buttons button {
+        border: 2px solid rgba(0, 0, 0, 0.2);
+        min-width: 3em;
+        padding: 10px;
+        float: left;
+        font-weight: bold;
+        color: rgba(0, 0, 0, 0.6);
       }
-      select#area option {
-        padding: 5px;
-        margin-right: 5px;
-        text-align: center;
-        display: inline-block;
-        border: solid 1px;
-        border-radius: 7px;
+      #area-buttons button:not(:last-child) {
+        border-right: none;
+      }
+      #area-buttons button:first-child {
+        border-radius: 8px 0 0 8px;
+      }
+      #area-buttons button:last-child {
+        border-radius: 0 8px 8px 0;
+      }
+      #area-buttons:after {
+        content: "";
+        clear: both;
+        display: table;
+      }
+      #area-buttons button:not(:first-child):hover,
+      #area-buttons button.active {
+        cursor: pointer;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 5px;
       }
       input.red {
         background-color: #fda4af;


### PR DESCRIPTION
Added the color coding for the area selector.

Hid the original area selector and created a button group. The button group listens for clicks and spoofs the onChange event for the original selector. This allows us to use the loadData function built into the page.